### PR TITLE
chore: added code

### DIFF
--- a/src/main/java/com/dream11/rest/AbstractRestVerticle.java
+++ b/src/main/java/com/dream11/rest/AbstractRestVerticle.java
@@ -1,0 +1,154 @@
+package com.dream11.rest;
+
+import com.dream11.rest.exception.mapper.GenericExceptionMapper;
+import com.dream11.rest.exception.mapper.ValidationExceptionMapper;
+import com.dream11.rest.exception.mapper.WebApplicationExceptionMapper;
+import com.dream11.rest.filter.LoggerFilter;
+import com.dream11.rest.filter.RequestResponseFilter;
+import com.dream11.rest.filter.TimeoutFilter;
+import com.dream11.rest.provider.JsonProvider;
+import com.dream11.rest.provider.ParamConverterProvider;
+import com.dream11.rest.provider.impl.JacksonProvider;
+import com.dream11.rest.util.AnnotationUtil;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Single;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.core.json.jackson.DatabindCodec;
+import io.vertx.rxjava3.core.AbstractVerticle;
+import io.vertx.rxjava3.core.Context;
+import io.vertx.rxjava3.core.RxHelper;
+import io.vertx.rxjava3.core.http.HttpServer;
+import io.vertx.rxjava3.core.http.HttpServerRequest;
+import io.vertx.rxjava3.ext.web.Router;
+import io.vertx.rxjava3.ext.web.handler.BodyHandler;
+import io.vertx.rxjava3.ext.web.handler.ResponseContentTypeHandler;
+import io.vertx.rxjava3.ext.web.handler.StaticHandler;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.ext.Provider;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.jboss.resteasy.plugins.server.vertx.VertxRequestHandler;
+import org.jboss.resteasy.plugins.server.vertx.VertxResteasyDeployment;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+
+/**
+ * Starts backpressure enabled HTTP server and registers providers in resteasy deployment.
+ */
+@Slf4j
+public abstract class AbstractRestVerticle extends AbstractVerticle {
+
+  final String packageName;
+  final HttpServerOptions httpServerOptions;
+  HttpServer httpServer;
+
+  protected AbstractRestVerticle(String packageName) {
+    this(packageName, new HttpServerOptions());
+  }
+
+  protected AbstractRestVerticle(String packageName, HttpServerOptions httpServerOptions) {
+    this.packageName = packageName;
+    this.httpServerOptions = httpServerOptions;
+  }
+
+  protected abstract ClassInjector getInjector();
+
+  protected RequestResponseFilter getReqResFilter() {
+    return new LoggerFilter();
+  }
+
+  protected JsonProvider getJsonProvider() {
+    return new JacksonProvider(DatabindCodec.mapper());
+  }
+
+  @Override
+  public Completable rxStart() {
+    return this.startHttpServer().doOnSuccess(server -> this.httpServer = server).ignoreElement();
+  }
+
+  private Single<HttpServer> startHttpServer() {
+    VertxResteasyDeployment deployment = this.buildResteasyDeployment();
+    Router router = this.getRouter();
+    VertxRequestHandler vertxRequestHandler = new VertxRequestHandler(vertx.getDelegate(), deployment);
+    val server = vertx.createHttpServer(this.httpServerOptions);
+    val handleRequests = server.requestStream()
+        .toFlowable()
+        .map(HttpServerRequest::pause)
+        .onBackpressureDrop(req -> {
+          log.error("Dropping request with status 503");
+          req.getDelegate().response().setStatusCode(503).end();
+        })
+        .observeOn(RxHelper.scheduler(new Context(this.context))) // For backpressure
+        .doOnNext(req -> {
+          if (req.path().matches("/swagger(.*)")) {
+            router.handle(req);
+          } else {
+            vertxRequestHandler.handle(req.getDelegate());
+          }
+        })
+        .map(HttpServerRequest::resume)
+        .doOnError(error -> log.error("Uncaught ERROR while handling request", error))
+        .ignoreElements();
+
+    return server
+        .rxListen()
+        .doOnSuccess(res -> log.info("Started http server at port: {} for package: {}", this.httpServerOptions.getPort(), packageName))
+        .doOnError(error -> log.error(
+            "Failed to start http server at port : {} with error: {}", this.httpServerOptions.getPort(), error.getMessage()))
+        .doOnSubscribe(disposable -> handleRequests.subscribe());
+  }
+
+  protected Router getRouter() {
+    Router router = Router.router(vertx);
+    router.route().handler(BodyHandler.create());
+    router.route().handler(ResponseContentTypeHandler.create());
+    router.route().handler(StaticHandler.create());
+    return router;
+  }
+
+  @Override
+  public Completable rxStop() {
+    if (this.httpServer != null) {
+      return this.httpServer.rxClose()
+          .doOnComplete(() -> log.info("http server stopped successfully"))
+          .doOnError(err -> log.info("Failed to stop http server", err));
+    }
+    return Completable.complete();
+  }
+
+  protected VertxResteasyDeployment buildResteasyDeployment() {
+    VertxResteasyDeployment deployment = new VertxResteasyDeployment();
+    deployment.start();
+    List<Class<?>> routes = AnnotationUtil.getClassesWithAnnotation(packageName, Path.class);
+    log.info("JAX-RS routes : " + routes.size());
+    this.registerProviders(deployment.getProviderFactory());
+
+    // not using deployment.getRegistry().addPerInstanceResource because it creates new instance of resource for each request
+    routes.forEach(route -> deployment.getRegistry().addSingletonResource(this.getInjector().getInstance(route)));
+    return deployment;
+  }
+
+  private void registerProviders(ResteasyProviderFactory resteasyProviderFactory) {
+    this.getProviderObjects().forEach(resteasyProviderFactory::register);
+    this.getProviders().forEach(resteasyProviderFactory::register);
+  }
+
+  protected List<Class<?>> getProviders() {
+    List<Class<?>> providers = new ArrayList<>();
+    providers.add(TimeoutFilter.class);
+    providers.add(ValidationExceptionMapper.class);
+    providers.add(GenericExceptionMapper.class);
+    providers.add(WebApplicationExceptionMapper.class);
+    providers.add(ParamConverterProvider.class);
+    providers.add(this.getReqResFilter().getClass());
+    providers.addAll(AnnotationUtil.getClassesWithAnnotation(packageName, Provider.class));
+    return providers;
+  }
+
+  protected List<Object> getProviderObjects() {
+    List<Object> providerObjects = new ArrayList<>();
+    providerObjects.add(this.getJsonProvider());
+    return providerObjects;
+  }
+}

--- a/src/main/java/com/dream11/rest/ClassInjector.java
+++ b/src/main/java/com/dream11/rest/ClassInjector.java
@@ -1,0 +1,8 @@
+package com.dream11.rest;
+
+public interface ClassInjector {
+  /**
+   * Returns the appropriate instance for the given injection type.
+   */
+  <T> T getInstance(Class<T> clazz);
+}

--- a/src/main/java/com/dream11/rest/annotation/Timeout.java
+++ b/src/main/java/com/dream11/rest/annotation/Timeout.java
@@ -1,0 +1,19 @@
+package com.dream11.rest.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.apache.http.HttpStatus;
+
+/**
+ * Can be applied on JAX-RS method or class.
+ * Annotation on method overrides annotation on class.
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(value = RetentionPolicy.RUNTIME)
+public @interface Timeout {
+  long value(); // ms
+
+  int httpStatusCode() default HttpStatus.SC_INTERNAL_SERVER_ERROR;
+}

--- a/src/main/java/com/dream11/rest/annotation/TypeValidationError.java
+++ b/src/main/java/com/dream11/rest/annotation/TypeValidationError.java
@@ -1,0 +1,19 @@
+package com.dream11.rest.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * RestException with following code and message will be thrown upon parsing error.
+ */
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(value = RetentionPolicy.RUNTIME)
+public @interface TypeValidationError {
+  String code();
+
+  String message();
+
+  int httpStatusCode() default 400;
+}

--- a/src/main/java/com/dream11/rest/converter/BaseParamConverter.java
+++ b/src/main/java/com/dream11/rest/converter/BaseParamConverter.java
@@ -1,0 +1,40 @@
+package com.dream11.rest.converter;
+
+import com.dream11.rest.annotation.TypeValidationError;
+import com.dream11.rest.exception.RestException;
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.function.Function;
+
+public class BaseParamConverter {
+
+  String errorMessage;
+  String errorCode;
+  Integer httpStatusCode;
+
+  public BaseParamConverter(Annotation[] annotations) {
+    Optional<TypeValidationError> optionalAnnotation =
+        Arrays.stream(annotations)
+            .filter(annotation -> annotation.annotationType() == TypeValidationError.class)
+            .map(TypeValidationError.class::cast)
+            .findAny();
+    optionalAnnotation.ifPresent(typeValidationError -> {
+      this.errorCode = typeValidationError.code();
+      this.errorMessage = typeValidationError.message();
+      this.httpStatusCode = typeValidationError.httpStatusCode();
+    });
+  }
+
+  protected <T> T parseParam(String s, Function<String, T> parseMethod) {
+    try {
+      return parseMethod.apply(s);
+    } catch (Exception e) {
+      if (this.errorMessage != null) {
+        throw new RestException(this.errorCode, this.errorMessage, this.httpStatusCode, e);
+      } else {
+        throw e;
+      }
+    }
+  }
+}

--- a/src/main/java/com/dream11/rest/converter/DoubleParamConverter.java
+++ b/src/main/java/com/dream11/rest/converter/DoubleParamConverter.java
@@ -1,0 +1,21 @@
+package com.dream11.rest.converter;
+
+import jakarta.ws.rs.ext.ParamConverter;
+import java.lang.annotation.Annotation;
+
+public class DoubleParamConverter extends BaseParamConverter implements ParamConverter<Double> {
+
+  public DoubleParamConverter(Annotation[] annotations) {
+    super(annotations);
+  }
+
+  @Override
+  public Double fromString(String s) {
+    return this.parseParam(s, Double::parseDouble);
+  }
+
+  @Override
+  public String toString(Double d) {
+    return d.toString();
+  }
+}

--- a/src/main/java/com/dream11/rest/converter/FloatParamConverter.java
+++ b/src/main/java/com/dream11/rest/converter/FloatParamConverter.java
@@ -1,0 +1,21 @@
+package com.dream11.rest.converter;
+
+import jakarta.ws.rs.ext.ParamConverter;
+import java.lang.annotation.Annotation;
+
+public class FloatParamConverter extends BaseParamConverter implements ParamConverter<Float> {
+
+  public FloatParamConverter(Annotation[] annotations) {
+    super(annotations);
+  }
+
+  @Override
+  public Float fromString(String s) {
+    return this.parseParam(s, Float::parseFloat);
+  }
+
+  @Override
+  public String toString(Float f) {
+    return f.toString();
+  }
+}

--- a/src/main/java/com/dream11/rest/converter/IntegerParamConverter.java
+++ b/src/main/java/com/dream11/rest/converter/IntegerParamConverter.java
@@ -1,0 +1,21 @@
+package com.dream11.rest.converter;
+
+import jakarta.ws.rs.ext.ParamConverter;
+import java.lang.annotation.Annotation;
+
+public class IntegerParamConverter extends BaseParamConverter implements ParamConverter<Integer> {
+
+  public IntegerParamConverter(Annotation[] annotations) {
+    super(annotations);
+  }
+
+  @Override
+  public Integer fromString(String s) {
+    return this.parseParam(s, Integer::parseInt);
+  }
+
+  @Override
+  public String toString(Integer i) {
+    return i.toString();
+  }
+}

--- a/src/main/java/com/dream11/rest/converter/LongParamConverter.java
+++ b/src/main/java/com/dream11/rest/converter/LongParamConverter.java
@@ -1,0 +1,22 @@
+package com.dream11.rest.converter;
+
+
+import jakarta.ws.rs.ext.ParamConverter;
+import java.lang.annotation.Annotation;
+
+public class LongParamConverter extends BaseParamConverter implements ParamConverter<Long> {
+
+  public LongParamConverter(Annotation[] annotations) {
+    super(annotations);
+  }
+
+  @Override
+  public Long fromString(String s) {
+    return this.parseParam(s, Long::parseLong);
+  }
+
+  @Override
+  public String toString(Long l) {
+    return l.toString();
+  }
+}

--- a/src/main/java/com/dream11/rest/exception/RestError.java
+++ b/src/main/java/com/dream11/rest/exception/RestError.java
@@ -1,0 +1,11 @@
+package com.dream11.rest.exception;
+
+public interface RestError {
+
+  String getErrorCode();
+
+  String getErrorMessage();
+
+  int getHttpStatusCode();
+
+}

--- a/src/main/java/com/dream11/rest/exception/RestException.java
+++ b/src/main/java/com/dream11/rest/exception/RestException.java
@@ -1,0 +1,48 @@
+package com.dream11.rest.exception;
+
+import io.vertx.core.json.JsonObject;
+import lombok.Getter;
+
+@Getter
+public class RestException extends RuntimeException {
+
+  final String errorMessage;
+  final String errorCode;
+  final Integer httpStatusCode;
+
+  public RestException(String errorCode, String errorMessage, Integer httpStatusCode) {
+    this(errorCode, errorMessage, httpStatusCode, null);
+  }
+
+  public RestException(String errorCode, String errorMessage, Integer httpStatusCode, Throwable throwable) {
+    super(errorMessage, throwable);
+    this.errorCode = errorCode;
+    this.errorMessage = errorMessage;
+    this.httpStatusCode = httpStatusCode;
+  }
+
+  public RestException(RestError restError) {
+    this(restError, null);
+  }
+
+  public RestException(RestError restError, Throwable cause) {
+    super(restError.getErrorMessage(), cause);
+    this.errorCode = restError.getErrorCode();
+    this.errorMessage = restError.getErrorMessage();
+    this.httpStatusCode = restError.getHttpStatusCode();
+  }
+
+  public JsonObject toJson() {
+    JsonObject errorJson = new JsonObject()
+        .put("message", this.errorMessage)
+        .put("cause", this.getCause() == null ? this.getMessage() : this.getCause().getMessage())
+        .put("code", this.errorCode);
+    return new JsonObject()
+        .put("error", errorJson);
+  }
+
+  @Override
+  public String toString() {
+    return this.toJson().toString();
+  }
+}

--- a/src/main/java/com/dream11/rest/exception/impl/RestErrorEnum.java
+++ b/src/main/java/com/dream11/rest/exception/impl/RestErrorEnum.java
@@ -1,0 +1,18 @@
+package com.dream11.rest.exception.impl;
+
+import com.dream11.rest.exception.RestError;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.apache.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum RestErrorEnum implements RestError {
+
+  UNKNOWN_EXCEPTION("UNKNOWN_EXCEPTION", "Something went wrong", HttpStatus.SC_INTERNAL_SERVER_ERROR),
+  INVALID_REQUEST("INVALID_REQUEST", "The request violates one or more constraints: %s", HttpStatus.SC_BAD_REQUEST);
+
+  final String errorCode;
+  final String errorMessage;
+  final int httpStatusCode;
+}

--- a/src/main/java/com/dream11/rest/exception/mapper/GenericExceptionMapper.java
+++ b/src/main/java/com/dream11/rest/exception/mapper/GenericExceptionMapper.java
@@ -1,0 +1,19 @@
+package com.dream11.rest.exception.mapper;
+
+import com.dream11.rest.exception.RestException;
+import com.dream11.rest.util.ExceptionUtil;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import lombok.extern.slf4j.Slf4j;
+
+
+@Slf4j
+public class GenericExceptionMapper implements ExceptionMapper<Throwable> {
+  @Override
+  public Response toResponse(Throwable throwable) {
+    RestException restException = (RestException) ExceptionUtil.parseThrowable(throwable);
+    log.error("Error: " + restException.getErrorCode() + " " + restException.getHttpStatusCode()
+        + " " + restException.getErrorMessage(), throwable);
+    return Response.status(restException.getHttpStatusCode()).entity(restException.toString()).build();
+  }
+}

--- a/src/main/java/com/dream11/rest/exception/mapper/ValidationExceptionMapper.java
+++ b/src/main/java/com/dream11/rest/exception/mapper/ValidationExceptionMapper.java
@@ -1,0 +1,19 @@
+package com.dream11.rest.exception.mapper;
+
+import com.dream11.rest.exception.RestException;
+import com.dream11.rest.exception.impl.RestErrorEnum;
+import com.dream11.rest.util.ExceptionUtil;
+import jakarta.validation.ValidationException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class ValidationExceptionMapper implements ExceptionMapper<ValidationException> {
+
+  public Response toResponse(ValidationException validationException) {
+    log.error("Constraint violation", validationException);
+    RestException restException = ExceptionUtil.getException(RestErrorEnum.INVALID_REQUEST, validationException.getMessage());
+    return Response.status(Response.Status.BAD_REQUEST).entity(restException.toString()).build();
+  }
+}

--- a/src/main/java/com/dream11/rest/exception/mapper/WebApplicationExceptionMapper.java
+++ b/src/main/java/com/dream11/rest/exception/mapper/WebApplicationExceptionMapper.java
@@ -1,0 +1,21 @@
+package com.dream11.rest.exception.mapper;
+
+import com.dream11.rest.exception.RestException;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class WebApplicationExceptionMapper implements ExceptionMapper<WebApplicationException> {
+
+  public Response toResponse(WebApplicationException webApplicationException) {
+    log.error("Error occurred", webApplicationException);
+    RestException restException =
+        webApplicationException.getCause() instanceof RestException ? (RestException) webApplicationException.getCause() :
+            new RestException("UNSUPPORTED_REQUEST",
+                webApplicationException.getResponse().getStatusInfo().getReasonPhrase(),
+                webApplicationException.getResponse().getStatus(), webApplicationException);
+    return Response.status(restException.getHttpStatusCode()).entity(restException.toString()).build();
+  }
+}

--- a/src/main/java/com/dream11/rest/filter/LoggerFilter.java
+++ b/src/main/java/com/dream11/rest/filter/LoggerFilter.java
@@ -1,0 +1,53 @@
+package com.dream11.rest.filter;
+
+import com.dream11.rest.util.RestUtil;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.ext.Provider;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.IOUtils;
+
+@Slf4j
+@Provider
+public class LoggerFilter extends RequestResponseFilter {
+
+  static final String REQUEST_START_TIME = "REQUEST_START_TIME";
+
+  @Override
+  protected String getResponseString(Object response) throws JsonProcessingException {
+    return RestUtil.objectToString(response);
+  }
+
+  @Override
+  public void filter(ContainerRequestContext containerRequestContext, ContainerResponseContext containerResponseContext)
+      throws IOException {
+    super.filter(containerRequestContext, containerResponseContext);
+    if (containerRequestContext.getProperty(REQUEST_START_TIME) != null) {
+      log.debug("[RESPONSE TIME] Time taken for route: {} {} : {}ms, Status code : {}", containerRequestContext.getMethod(),
+          containerRequestContext.getUriInfo().getPath(),
+          System.currentTimeMillis() - (Long) containerRequestContext.getProperty(REQUEST_START_TIME),
+          containerResponseContext.getStatus()
+      );
+      containerRequestContext.removeProperty(REQUEST_START_TIME);
+    }
+  }
+
+  @Override
+  public void filter(ContainerRequestContext containerRequestContext) throws IOException {
+    containerRequestContext.setProperty(REQUEST_START_TIME, System.currentTimeMillis());
+
+    log.debug("STATED REQUEST : {} {}", containerRequestContext.getMethod(), containerRequestContext.getUriInfo().getPath());
+    String body = "{}";
+    if (containerRequestContext.hasEntity() && containerRequestContext.getEntityStream() != null) {
+      body = IOUtils.toString(containerRequestContext.getEntityStream(), StandardCharsets.UTF_8).replace("\n", " ");
+      containerRequestContext.getEntityStream().reset();
+    }
+    log.debug("Path: {} {}  Request: Body : {}, Headers : {}, PathParams : {}, QueryParams : {}", containerRequestContext.getMethod(),
+        containerRequestContext.getUriInfo().getPath(), body, containerRequestContext.getHeaders(),
+        containerRequestContext.getUriInfo().getPathParameters(),
+        containerRequestContext.getUriInfo().getQueryParameters());
+  }
+}

--- a/src/main/java/com/dream11/rest/filter/RequestResponseFilter.java
+++ b/src/main/java/com/dream11/rest/filter/RequestResponseFilter.java
@@ -1,0 +1,19 @@
+package com.dream11.rest.filter;
+
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+import java.io.IOException;
+
+public abstract class RequestResponseFilter implements ContainerResponseFilter, ContainerRequestFilter {
+  protected abstract String getResponseString(Object response) throws IOException;
+
+  @Override
+  public void filter(ContainerRequestContext containerRequestContext, ContainerResponseContext containerResponseContext)
+      throws IOException {
+    if (containerResponseContext.hasEntity()) {
+      containerResponseContext.setEntity(getResponseString(containerResponseContext.getEntity()));
+    }
+  }
+}

--- a/src/main/java/com/dream11/rest/filter/TimeoutFilter.java
+++ b/src/main/java/com/dream11/rest/filter/TimeoutFilter.java
@@ -1,0 +1,73 @@
+package com.dream11.rest.filter;
+
+import com.dream11.rest.annotation.Timeout;
+import com.dream11.rest.exception.RestException;
+import io.vertx.rxjava3.core.Vertx;
+import jakarta.ws.rs.container.AsyncResponse;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.container.ResourceInfo;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.ext.Provider;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.http.HttpStatus;
+import org.jboss.resteasy.core.interception.jaxrs.PostMatchContainerRequestContext;
+
+
+@Slf4j
+@Provider
+public class TimeoutFilter implements ContainerRequestFilter, ContainerResponseFilter {
+
+  static final String TIMER_ID = "__TIMER_ID__";
+  static final Long DEFAULT_TIMEOUT = 20000L;
+  static final int DEFAULT_HTTP_STATUS_CODE = HttpStatus.SC_INTERNAL_SERVER_ERROR;
+  final Vertx vertx = Vertx.currentContext().owner();
+  @Context
+  private ResourceInfo resourceInfo;
+
+  /**
+   * Cancel the vertx timer created for timeout.
+   *
+   * @param containerRequestContext  requestContext
+   * @param containerResponseContext responseContext
+   */
+  @Override
+  public void filter(ContainerRequestContext containerRequestContext, ContainerResponseContext containerResponseContext) {
+    if (containerRequestContext.getProperty(TIMER_ID) != null) {
+      vertx.cancelTimer((Long) containerRequestContext.getProperty(TIMER_ID));
+      containerRequestContext.removeProperty(TIMER_ID);
+    }
+  }
+
+  /**
+   * Gets timeout from annotation and create a vertx timer that throws RestException after timeout period.
+   *
+   * @param containerRequestContext requestContext
+   */
+  @Override
+  public void filter(ContainerRequestContext containerRequestContext) {
+    Timeout resourceMethodAnnotation = resourceInfo.getResourceMethod().getAnnotation(Timeout.class);
+    Timeout resourceClassAnnotation = resourceInfo.getResourceClass().getAnnotation(Timeout.class);
+    // check timeout annotation on resource method then check on resource class
+    long timeout;
+    int httpStatusCode;
+    if (resourceMethodAnnotation == null) {
+      timeout = resourceClassAnnotation == null ? DEFAULT_TIMEOUT : resourceClassAnnotation.value();
+      httpStatusCode = resourceClassAnnotation == null ? DEFAULT_HTTP_STATUS_CODE : resourceClassAnnotation.httpStatusCode();
+    } else {
+      timeout = resourceMethodAnnotation.value();
+      httpStatusCode = resourceMethodAnnotation.httpStatusCode();
+    }
+    AsyncResponse asyncResponse =
+        ((PostMatchContainerRequestContext) containerRequestContext).getHttpRequest().getAsyncContext().getAsyncResponse();
+
+    // not using asyncResponse.setTimeout(timeout) because it creates a vertx timer but do not cancel it upon request completion
+    if (timeout > 0 && !asyncResponse.isCancelled() && !asyncResponse.isDone()) {
+      long timerId = vertx.setTimer(timeout, id -> asyncResponse.resume(new RestException(
+          "REQUEST_TIMEOUT", String.format("Request timed out after %dms", timeout), httpStatusCode)));
+      containerRequestContext.setProperty(TIMER_ID, timerId);
+    }
+  }
+}

--- a/src/main/java/com/dream11/rest/package-info.java
+++ b/src/main/java/com/dream11/rest/package-info.java
@@ -1,0 +1,4 @@
+@ModuleGen(groupPackage = "com.dream11.rest", name = "rest")
+package com.dream11.rest;
+
+import io.vertx.codegen.annotations.ModuleGen;

--- a/src/main/java/com/dream11/rest/provider/JsonProvider.java
+++ b/src/main/java/com/dream11/rest/provider/JsonProvider.java
@@ -1,0 +1,3 @@
+package com.dream11.rest.provider;
+
+public interface JsonProvider {}

--- a/src/main/java/com/dream11/rest/provider/ParamConverterProvider.java
+++ b/src/main/java/com/dream11/rest/provider/ParamConverterProvider.java
@@ -1,0 +1,27 @@
+package com.dream11.rest.provider;
+
+import com.dream11.rest.converter.DoubleParamConverter;
+import com.dream11.rest.converter.FloatParamConverter;
+import com.dream11.rest.converter.IntegerParamConverter;
+import com.dream11.rest.converter.LongParamConverter;
+import jakarta.ws.rs.ext.ParamConverter;
+import jakarta.ws.rs.ext.Provider;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+@Provider
+public class ParamConverterProvider implements jakarta.ws.rs.ext.ParamConverterProvider {
+  @Override
+  public <T> ParamConverter<T> getConverter(Class<T> rawType, Type genericType, Annotation[] annotations) {
+    if (rawType == Long.class) {
+      return (ParamConverter<T>) new LongParamConverter(annotations);
+    } else if (rawType == Integer.class) {
+      return (ParamConverter<T>) new IntegerParamConverter(annotations);
+    } else if (rawType == Double.class) {
+      return (ParamConverter<T>) new DoubleParamConverter(annotations);
+    } else if (rawType == Float.class) {
+      return (ParamConverter<T>) new FloatParamConverter(annotations);
+    }
+    return null;
+  }
+}

--- a/src/main/java/com/dream11/rest/provider/impl/JacksonProvider.java
+++ b/src/main/java/com/dream11/rest/provider/impl/JacksonProvider.java
@@ -1,0 +1,54 @@
+package com.dream11.rest.provider.impl;
+
+import com.dream11.rest.annotation.TypeValidationError;
+import com.dream11.rest.exception.RestException;
+import com.dream11.rest.provider.JsonProvider;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.Provider;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.List;
+import lombok.SneakyThrows;
+import org.apache.http.HttpStatus;
+import org.jboss.resteasy.plugins.providers.jackson.ResteasyJackson2Provider;
+
+@Provider
+@Consumes({"application/json", "application/*+json", "text/json"})
+@Produces({"application/json", "application/*+json", "text/json"})
+public class JacksonProvider extends ResteasyJackson2Provider implements JsonProvider {
+
+  public JacksonProvider(ObjectMapper mapper) {
+    this.setMapper(mapper);
+  }
+
+  @SneakyThrows
+  @Override
+  public Object readFrom(Class<Object> type, Type genericType, Annotation[] annotations, MediaType mediaType,
+                         MultivaluedMap<String, String> httpHeaders, InputStream entityStream) {
+    try {
+      return super.readFrom(type, genericType, annotations, mediaType, httpHeaders, entityStream);
+    } catch (JsonMappingException e) {
+      List<JsonMappingException.Reference> referenceList = e.getPath();
+      if (!referenceList.isEmpty()) {
+        String fieldName = referenceList.get(0).getFieldName();
+        if (fieldName != null) {
+          TypeValidationError typeValidationError = type.getDeclaredField(fieldName).getAnnotation(TypeValidationError.class);
+          if (typeValidationError != null) {
+            throw new RestException(typeValidationError.code(), typeValidationError.message(),
+                typeValidationError.httpStatusCode(), e);
+          }
+        }
+      }
+      throw new RestException("INVALID_REQUEST", e.getMessage(), HttpStatus.SC_BAD_REQUEST, e);
+    } catch (IOException e) {
+      throw new RestException("INVALID_REQUEST", e.getMessage(), HttpStatus.SC_BAD_REQUEST, e);
+    }
+  }
+}

--- a/src/main/java/com/dream11/rest/util/AnnotationUtil.java
+++ b/src/main/java/com/dream11/rest/util/AnnotationUtil.java
@@ -1,0 +1,15 @@
+package com.dream11.rest.util;
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.experimental.UtilityClass;
+import org.reflections.Reflections;
+
+@UtilityClass
+public class AnnotationUtil {
+  public List<Class<?>> getClassesWithAnnotation(String packageName, Class<? extends Annotation> annotation) {
+    Reflections ref = new Reflections(packageName);
+    return new ArrayList<>(ref.getTypesAnnotatedWith(annotation));
+  }
+}

--- a/src/main/java/com/dream11/rest/util/ExceptionUtil.java
+++ b/src/main/java/com/dream11/rest/util/ExceptionUtil.java
@@ -1,0 +1,20 @@
+package com.dream11.rest.util;
+
+import com.dream11.rest.exception.RestError;
+import com.dream11.rest.exception.RestException;
+import com.dream11.rest.exception.impl.RestErrorEnum;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class ExceptionUtil {
+
+  public Throwable parseThrowable(Throwable throwable) {
+    return throwable instanceof RestException ? throwable :
+        new RestException(RestErrorEnum.UNKNOWN_EXCEPTION, throwable);
+  }
+
+  public RestException getException(RestError restError, Object... params) {
+    String message = String.format(restError.getErrorMessage(), params);
+    return new RestException(restError.getErrorCode(), message, restError.getHttpStatusCode());
+  }
+}

--- a/src/main/java/com/dream11/rest/util/RestUtil.java
+++ b/src/main/java/com/dream11/rest/util/RestUtil.java
@@ -1,0 +1,25 @@
+package com.dream11.rest.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.jackson.DatabindCodec;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class RestUtil {
+
+  public String objectToString(Object object) throws JsonProcessingException {
+    ObjectMapper objectMapper = DatabindCodec.mapper();
+    String str;
+    if (object instanceof String) {
+      str = (String) object;
+    } else if (object instanceof JsonObject || object instanceof JsonArray) {
+      str = String.valueOf(object);
+    } else {
+      str = objectMapper.writeValueAsString(object);
+    }
+    return str;
+  }
+}

--- a/src/test/java/com/dream11/rest/Constants.java
+++ b/src/test/java/com/dream11/rest/Constants.java
@@ -1,0 +1,12 @@
+package com.dream11.rest;
+
+public class Constants {
+  public static final String TEST_PACKAGE_NAME = "com.dream11.rest";
+
+  public static final String VALIDATION_ROUTE_PATH = "/validation";
+  public static final String TIMEOUT_ROUTE_PATH = "/timeout";
+
+  public static final Integer APPLICATION_PORT = 8080;
+
+  public static final String SHARED_DATA_MAP_NAME = "__vertx.sharedDataUtils";
+}

--- a/src/test/java/com/dream11/rest/RestApiIT.java
+++ b/src/test/java/com/dream11/rest/RestApiIT.java
@@ -1,0 +1,173 @@
+package com.dream11.rest;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.reactivex.rxjava3.core.Single;
+import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.rxjava3.core.MultiMap;
+import io.vertx.rxjava3.core.Vertx;
+import io.vertx.rxjava3.core.buffer.Buffer;
+import io.vertx.rxjava3.ext.web.client.HttpResponse;
+import io.vertx.rxjava3.ext.web.client.WebClient;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+@ExtendWith({VertxExtension.class, Setup.class})
+@Slf4j
+class RestApiIT {
+
+  final WebClient webClient = WebClient.create(Vertx.vertx());
+
+  @Test
+  void nullHeaderTest() {
+    // arrange
+    String path = String.format("%s/1?testFilter=query&double=1.1&float=1.1&integer=1&long=1", Constants.VALIDATION_ROUTE_PATH);
+    // act
+    int statusCode = this.makeGetRequest(path)
+        .map(HttpResponse::statusCode)
+        .blockingGet();
+    // assert
+    assertThat(statusCode).isEqualTo(400);
+  }
+
+  @Test
+  void nullQueryParamTest() {
+    // arrange
+    String path = String.format("%s/1", Constants.VALIDATION_ROUTE_PATH);
+    MultiMap headers = MultiMap.caseInsensitiveMultiMap().add("testHeader", "1");
+    // act
+    int statusCode = this.makeGetRequest(path, headers)
+        .map(HttpResponse::statusCode)
+        .blockingGet();
+    // assert
+    assertThat(statusCode).isEqualTo(400);
+  }
+
+  @ParameterizedTest
+  @CsvSource({"/class", "/method"})
+  void timeoutAnnotationTest(String param) {
+    // arrange
+    String path = String.format("%s%s", Constants.TIMEOUT_ROUTE_PATH, param);
+    // act
+    int statusCode = this.makeGetRequest(path)
+        .map(HttpResponse::statusCode)
+        .blockingGet();
+    // assert
+    assertThat(statusCode).isEqualTo(503);
+  }
+
+  @ParameterizedTest
+  @CsvSource({"integer", "long", "float", "double"})
+  void typeTypeValidationParamTest(String param) {
+    // arrange
+    String path = String.format("%s/1?testFilter=query&%s=param", Constants.VALIDATION_ROUTE_PATH, param);
+    MultiMap headers = MultiMap.caseInsensitiveMultiMap().add("testHeader", "1");
+    // act
+    HttpResponse<Buffer> response = this.makeGetRequest(path, headers)
+        .blockingGet();
+    JsonObject responseBody = response.bodyAsJsonObject();
+    // assert
+    assertThat(response.statusCode()).isEqualTo(400);
+    assertThat(responseBody.getJsonObject("error").getString("code")).isEqualTo("BAD_REQUEST");
+    assertThat(responseBody.getJsonObject("error").getString("message")).isEqualTo(
+        String.format("Query param '%s' must be %s", param, param));
+  }
+
+  @Test
+  void validateBodyTest() {
+    // arrange
+    String path = String.format("%s", Constants.VALIDATION_ROUTE_PATH);
+    JsonObject body = new JsonObject().put("resourceId", "Hello");
+    // act
+    HttpResponse<Buffer> response = this.makePostRequest(path, body)
+        .blockingGet();
+    JsonObject responseBody = response.bodyAsJsonObject();
+    // assert
+    assertThat(response.statusCode()).isEqualTo(400);
+    assertThat(responseBody.getJsonObject("error").getString("code")).isEqualTo("BAD_REQUEST");
+    assertThat(responseBody.getJsonObject("error").getString("message")).isEqualTo("resourceId must be integer");
+  }
+
+  @Test
+  void positiveBodyTest() {
+    // arrange
+    String path = String.format("%s", Constants.VALIDATION_ROUTE_PATH);
+    JsonObject body = new JsonObject().put("resourceId", "1");
+    // act
+    HttpResponse<Buffer> response = this.makePostRequest(path, body)
+        .blockingGet();
+    // assert
+    assertThat(response.statusCode()).isEqualTo(200);
+  }
+
+  @Test
+  void extraFieldsTest() {
+    // arrange
+    String path = String.format("%s", Constants.VALIDATION_ROUTE_PATH);
+    JsonObject body = new JsonObject().put("resourceId", "1").put("extraKey", "extraValue");
+    // act
+    HttpResponse<Buffer> response = this.makePostRequest(path, body)
+        .blockingGet();
+    // assert
+    assertThat(response.statusCode()).isEqualTo(200);
+  }
+
+  @Test
+  void routeNotFoundTest() {
+    // arrange
+    String path = "/nonexistent";
+    // act
+    int statusCode = this.makeGetRequest(path)
+        .map(HttpResponse::statusCode)
+        .blockingGet();
+    // assert
+    assertThat(statusCode).isEqualTo(404);
+  }
+
+
+  @Test
+  @SneakyThrows
+  void testBackPressure() {
+    // arrange
+    JsonObject body = JsonObject.of("resourceId", "1");
+    List<Single<HttpResponse<Buffer>>> responseSingles = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      responseSingles.add(this.makePostRequest(Constants.VALIDATION_ROUTE_PATH, body));
+    }
+
+    // act
+    List<Integer> statusCodes = Single.merge(responseSingles)
+        .map(HttpResponse::statusCode)
+        .toList()
+        .blockingGet();
+
+    // assert
+    assertThat(statusCodes).contains(200, 503);
+  }
+
+  private Single<HttpResponse<Buffer>> makePostRequest(String path, JsonObject body) {
+    String uri = String.format("http://127.0.0.1:%s%s", Constants.APPLICATION_PORT, path);
+    return this.webClient.postAbs(uri)
+        .putHeader("Content-type", "application/json")
+        .rxSendJsonObject(body);
+  }
+
+  private Single<HttpResponse<Buffer>> makeGetRequest(String path, MultiMap headers) {
+    String uri = String.format("http://127.0.0.1:%s%s", Constants.APPLICATION_PORT, path);
+    return this.webClient.getAbs(uri)
+        .putHeaders(headers)
+        .rxSend();
+  }
+
+  private Single<HttpResponse<Buffer>> makeGetRequest(String path) {
+    return makeGetRequest(path, MultiMap.caseInsensitiveMultiMap());
+  }
+}

--- a/src/test/java/com/dream11/rest/Setup.java
+++ b/src/test/java/com/dream11/rest/Setup.java
@@ -1,0 +1,38 @@
+package com.dream11.rest;
+
+import com.dream11.rest.injector.GuiceInjector;
+import com.dream11.rest.util.SharedDataUtil;
+import com.dream11.rest.verticle.RestVerticle;
+import com.google.inject.Guice;
+import io.vertx.core.DeploymentOptions;
+import io.vertx.rxjava3.core.Vertx;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+@Slf4j
+public class Setup implements BeforeAllCallback, AfterAllCallback, ExtensionContext.Store.CloseableResource {
+  final Vertx vertx = Vertx.vertx();
+
+  @Override
+  public void afterAll(ExtensionContext extensionContext) {
+    this.vertx.rxClose().blockingAwait();
+  }
+
+  @Override
+  public void beforeAll(ExtensionContext extensionContext) {
+    GuiceInjector injector = new GuiceInjector(Guice.createInjector());
+    SharedDataUtil.setInstance(vertx.getDelegate(), injector);
+    final String verticleName = RestVerticle.class.getName();
+    System.setProperty("rx3.buffer-size", "1"); // Set rxjava buffer size
+    String __ = this.vertx.rxDeployVerticle(injector.getInstance(RestVerticle.class), new DeploymentOptions().setInstances(1))
+        .doOnError(error -> log.error("Error in deploying verticle : {}", verticleName, error))
+        .doOnSuccess(v -> log.info("Deployed verticle : {}", verticleName)).blockingGet();
+  }
+
+  @Override
+  public void close() {
+
+  }
+}

--- a/src/test/java/com/dream11/rest/dto/ValidationTestReqDTO.java
+++ b/src/test/java/com/dream11/rest/dto/ValidationTestReqDTO.java
@@ -1,0 +1,14 @@
+package com.dream11.rest.dto;
+
+import com.dream11.rest.annotation.TypeValidationError;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class ValidationTestReqDTO {
+  @NotNull
+  @TypeValidationError(code = "BAD_REQUEST", message = "resourceId must be integer")
+  Integer resourceId;
+}

--- a/src/test/java/com/dream11/rest/exception/RestAppError.java
+++ b/src/test/java/com/dream11/rest/exception/RestAppError.java
@@ -1,0 +1,16 @@
+package com.dream11.rest.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@RequiredArgsConstructor
+public enum RestAppError implements RestError {
+  UNKNOWN_EXCEPTION("UNKNOWN_EXCEPTION", "Error:%s, message:%s", 500);
+
+  final String errorCode;
+  final String errorMessage;
+  final int httpStatusCode;
+}

--- a/src/test/java/com/dream11/rest/exception/RestExceptionTest.java
+++ b/src/test/java/com/dream11/rest/exception/RestExceptionTest.java
@@ -1,0 +1,29 @@
+package com.dream11.rest.exception;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+class RestExceptionTest {
+  @Test
+  void testRestException() {
+    // arrange
+    String errorMessage = "An error has occurred";
+    Throwable cause = new RuntimeException(errorMessage);
+    RestError restError = RestAppError.UNKNOWN_EXCEPTION;
+
+    // act
+    RestException restException = new RestException(restError);
+    RestException restExceptionWithCause = new RestException(restError, cause);
+    // assert
+    assertThat(restException.getMessage()).isEqualTo(restError.getErrorMessage());
+    assertThat(restException.getHttpStatusCode()).isEqualTo(restError.getHttpStatusCode());
+    assertThat(restException.getErrorCode()).isEqualTo(restError.getErrorCode());
+
+    assertThat(restExceptionWithCause.getMessage()).isEqualTo(restError.getErrorMessage());
+    assertThat(restExceptionWithCause.getHttpStatusCode()).isEqualTo(restError.getHttpStatusCode());
+    assertThat(restExceptionWithCause.getErrorCode()).isEqualTo(restError.getErrorCode());
+    assertThat(restExceptionWithCause.getCause()).isEqualTo(cause);
+  }
+}

--- a/src/test/java/com/dream11/rest/injector/GuiceInjector.java
+++ b/src/test/java/com/dream11/rest/injector/GuiceInjector.java
@@ -1,0 +1,16 @@
+package com.dream11.rest.injector;
+
+import com.dream11.rest.ClassInjector;
+import com.google.inject.Injector;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class GuiceInjector implements ClassInjector {
+  final Injector injector;
+
+  @Override
+  public <T> T getInstance(Class<T> clazz) {
+    return this.injector.getInstance(clazz);
+  }
+}
+

--- a/src/test/java/com/dream11/rest/route/TimeoutRoute.java
+++ b/src/test/java/com/dream11/rest/route/TimeoutRoute.java
@@ -1,0 +1,46 @@
+package com.dream11.rest.route;
+
+import com.dream11.rest.annotation.Timeout;
+import com.dream11.rest.Constants;
+import io.reactivex.rxjava3.core.Single;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Path(Constants.TIMEOUT_ROUTE_PATH)
+@Timeout(value = 10, httpStatusCode = 503)
+public class TimeoutRoute {
+
+  @GET
+  @Path("/class")
+  @Consumes(MediaType.WILDCARD)
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiResponse(content = @Content(schema = @Schema(implementation = String.class)))
+  public CompletionStage<String> timeout() {
+    return Single.just("1")
+        .delay(20, TimeUnit.MILLISECONDS)
+        .toCompletionStage();
+  }
+
+  @GET
+  @Path("/method")
+  @Timeout(value = 10, httpStatusCode = 503)
+  @Consumes(MediaType.WILDCARD)
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiResponse(content = @Content(schema = @Schema(implementation = String.class)))
+  public CompletionStage<String> timeoutMethod() {
+    return Single.just("1")
+        .delay(20, TimeUnit.MILLISECONDS)
+        .toCompletionStage();
+  }
+}

--- a/src/test/java/com/dream11/rest/route/ValidationCheckRoute.java
+++ b/src/test/java/com/dream11/rest/route/ValidationCheckRoute.java
@@ -1,0 +1,55 @@
+package com.dream11.rest.route;
+
+import com.dream11.rest.annotation.Timeout;
+import com.dream11.rest.annotation.TypeValidationError;
+import com.dream11.rest.Constants;
+import com.dream11.rest.dto.ValidationTestReqDTO;
+import io.reactivex.rxjava3.core.Single;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.concurrent.CompletionStage;
+
+@Slf4j
+@Path(Constants.VALIDATION_ROUTE_PATH)
+@Timeout(value = 10000)
+public class ValidationCheckRoute {
+  @GET
+  @Path("{testResourceId}")
+  @Consumes(MediaType.WILDCARD)
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiResponse(content = @Content(schema = @Schema(implementation = String.class)))
+  public CompletionStage<String> getValidationTest(@NotNull @HeaderParam("testHeader") Integer testHeader,
+                                                   @NotNull @Positive @PathParam("testResourceId") Integer testResourceId,
+                                                   @NotBlank @QueryParam("testFilter") String testFilter,
+                                                   @TypeValidationError(code = "BAD_REQUEST", message = "Query param 'integer' must be "
+                                                       + "integer")
+                                                   @QueryParam("integer") Integer testIntParam,
+                                                   @TypeValidationError(code = "BAD_REQUEST", message = "Query param 'long' must be long")
+                                                   @QueryParam("long") Long testLongParam,
+                                                   @TypeValidationError(code = "BAD_REQUEST", message = "Query param 'float' must be float")
+                                                   @QueryParam("float") Float testFloatParam,
+                                                   @TypeValidationError(code = "BAD_REQUEST", message = "Query param 'double' must be double")
+                                                   @QueryParam("double") Double testDoubleParam) {
+    return Single.just(
+            String.format("Validation Successful! testHeader: %s, testResourceId: %s, testFilter: %s", testHeader, testResourceId, testFilter))
+        .toCompletionStage();
+  }
+
+  @POST
+  @Consumes(MediaType.WILDCARD)
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiResponse(content = @Content(schema = @Schema(implementation = String.class)))
+  public CompletionStage<String> postValidationTest(@Valid ValidationTestReqDTO reqDTO) {
+    return Single.just(String.format("Validation Successful! reqBody: %s", reqDTO.toString()))
+        .toCompletionStage();
+  }
+}

--- a/src/test/java/com/dream11/rest/util/AnnotationUtilTest.java
+++ b/src/test/java/com/dream11/rest/util/AnnotationUtilTest.java
@@ -1,0 +1,27 @@
+package com.dream11.rest.util;
+
+import com.dream11.rest.Constants;
+import com.dream11.rest.route.TimeoutRoute;
+import com.dream11.rest.route.ValidationCheckRoute;
+import jakarta.ws.rs.Path;
+import org.junit.jupiter.api.Test;
+
+import java.lang.annotation.Annotation;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AnnotationUtilTest {
+  @Test
+  void testAnnotatedClasses() {
+    // arrange
+    Class<? extends Annotation> annotation = Path.class;
+    // act
+    List<Class<?>> classes = AnnotationUtil.getClassesWithAnnotation(Constants.TEST_PACKAGE_NAME, annotation);
+    // assert
+    assertThat(classes)
+        .hasSize(2)
+        .contains(ValidationCheckRoute.class, TimeoutRoute.class);
+
+  }
+}

--- a/src/test/java/com/dream11/rest/util/ExceptionUtilTest.java
+++ b/src/test/java/com/dream11/rest/util/ExceptionUtilTest.java
@@ -1,0 +1,56 @@
+package com.dream11.rest.util;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.dream11.rest.exception.RestAppError;
+import com.dream11.rest.exception.RestError;
+import com.dream11.rest.exception.RestException;
+import com.dream11.rest.exception.impl.RestErrorEnum;
+import org.junit.jupiter.api.Test;
+
+class ExceptionUtilTest {
+  @Test
+  void testParseThrowable() {
+    // arrange
+    RestException exception = new RestException("REST_EXCEPTION", "Rest exception", 500);
+    // act
+    Throwable throwable = ExceptionUtil.parseThrowable(exception);
+    // assert
+    assertThat(throwable.getClass()).isEqualTo(RestException.class);
+    assertThat(throwable.getMessage()).isEqualTo(exception.getMessage());
+    assertThat(((RestException) throwable).getHttpStatusCode()).isEqualTo(exception.getHttpStatusCode());
+    assertThat(((RestException) throwable).getErrorCode()).isEqualTo(exception.getErrorCode());
+  }
+
+  @Test
+  void testGenericParseThrowable() {
+    // arrange
+    String message = "Test exception";
+    // act
+    Throwable throwable = ExceptionUtil.parseThrowable(new RuntimeException(message));
+    // assert
+    assertThat(throwable.getClass()).isEqualTo(RestException.class);
+    assertThat(((RestException) throwable).getHttpStatusCode()).isEqualTo(RestErrorEnum.UNKNOWN_EXCEPTION.getHttpStatusCode());
+    assertThat(((RestException) throwable).getErrorCode()).isEqualTo(RestErrorEnum.UNKNOWN_EXCEPTION.getErrorCode());
+    assertThat(throwable.getMessage()).isEqualTo(RestErrorEnum.UNKNOWN_EXCEPTION.getErrorMessage());
+    assertThat(throwable.getCause().getMessage()).isEqualTo(message);
+  }
+
+  @Test
+  void testGetException() {
+    // arrange
+    String errorMessage = "Error:Something went wrong, message:Error message";
+    RestError restError = RestAppError.UNKNOWN_EXCEPTION;
+
+    // act
+    RestException restException = ExceptionUtil.getException(restError, "Something went wrong", "Error message");
+
+    // assert
+    assertThat(restException.getHttpStatusCode()).isEqualTo(restError.getHttpStatusCode());
+    assertThat(restException.getErrorCode()).isEqualTo(restError.getErrorCode());
+    assertThat(restException.getMessage()).isEqualTo(errorMessage);
+    assertThat(restException.getMessage()).isEqualTo(restException.getErrorMessage());
+  }
+
+}

--- a/src/test/java/com/dream11/rest/util/RestUtilTest.java
+++ b/src/test/java/com/dream11/rest/util/RestUtilTest.java
@@ -1,0 +1,52 @@
+package com.dream11.rest.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class RestUtilTest {
+
+  @Test
+  void testListObjectToString() throws JsonProcessingException {
+    // arrange
+    List<Integer> integerList = Arrays.asList(1, 2, 3);
+    // act
+    String listToString = RestUtil.objectToString(integerList);
+    // assert
+    assertThat(listToString).isEqualTo("[1,2,3]");
+  }
+
+  @Test
+  void testStringObjectToString() throws JsonProcessingException {
+    // arrange
+    String message = "MESSAGE";
+    // assert
+    assertThat(RestUtil.objectToString(message)).isEqualTo(message);
+  }
+
+  @Test
+  void testJsonObjectToString() throws JsonProcessingException {
+    // arrange
+    JsonObject jsonObject = new JsonObject().put("key", "key");
+    // act
+    String jsonObjectString = RestUtil.objectToString(jsonObject);
+    // assert
+    assertThat(jsonObjectString).isEqualTo(jsonObject.toString());
+    assertThat(RestUtil.objectToString(jsonObject)).isEqualTo(jsonObject.toString());
+  }
+
+  @Test
+  void testJsonArrayToString() throws JsonProcessingException {
+    // arrange
+    JsonArray jsonArray = new JsonArray().add(1).add(2);
+    // act
+    String jsonArrayString = RestUtil.objectToString(jsonArray);
+    // assert
+    assertThat(jsonArrayString).isEqualTo(jsonArray.toString());
+  }
+}

--- a/src/test/java/com/dream11/rest/util/SharedDataUtil.java
+++ b/src/test/java/com/dream11/rest/util/SharedDataUtil.java
@@ -1,0 +1,56 @@
+package com.dream11.rest.util;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.shareddata.Shareable;
+import lombok.Getter;
+import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+
+import java.util.function.Supplier;
+
+@Slf4j
+@UtilityClass
+public final class SharedDataUtil {
+
+  private static final String SHARED_DATA_MAP_NAME = "__vertx.sharedDataUtils";
+  private static final String SHARED_DATA_CLASS_PREFIX = "__class.";
+  private static final String SHARED_DATA_DEFAULT_KEY = "__default.";
+
+
+  /**
+   * Returns a singleton shared object across vert.x instance
+   * Note: It is your responsibility to ensure T returned by supplier is thread-safe
+   */
+  public <T> T getOrCreate(Vertx vertx, String name, Supplier<T> supplier) {
+    val singletons = vertx.sharedData().getLocalMap(SHARED_DATA_MAP_NAME);
+    // LocalMap is internally backed by a ConcurrentMap
+    return ((ThreadSafe<T>) singletons.computeIfAbsent(name, k -> new ThreadSafe(supplier.get()))).getObject();
+  }
+
+  /**
+   * Helper wrapper on getOrCreate to setInstance.
+   * Note: Doesn't reset the instance if already exists
+   */
+  public <T> T setInstance(Vertx vertx, T instance) {
+    return getOrCreate(vertx, SHARED_DATA_CLASS_PREFIX + SHARED_DATA_DEFAULT_KEY + instance.getClass().getName(), () -> instance);
+  }
+
+  /**
+   * Helper wrapper on getOrCreate to getInstance.
+   */
+  public <T> T getInstance(Vertx vertx, Class<T> clazz) {
+    return getOrCreate(vertx, SHARED_DATA_CLASS_PREFIX + SHARED_DATA_DEFAULT_KEY + clazz.getName(), () -> {
+      throw new RuntimeException("Cannot find default instance of " + clazz.getName());
+    });
+  }
+
+  static class ThreadSafe<T> implements Shareable {
+    @Getter
+    final T object;
+
+    public ThreadSafe(T object) {
+      this.object = object;
+    }
+  }
+}

--- a/src/test/java/com/dream11/rest/verticle/RestVerticle.java
+++ b/src/test/java/com/dream11/rest/verticle/RestVerticle.java
@@ -1,0 +1,30 @@
+
+package com.dream11.rest.verticle;
+
+import com.dream11.rest.AbstractRestVerticle;
+import com.dream11.rest.ClassInjector;
+import com.dream11.rest.Constants;
+import com.dream11.rest.injector.GuiceInjector;
+import com.dream11.rest.provider.JsonProvider;
+import com.dream11.rest.provider.impl.JacksonProvider;
+import com.dream11.rest.util.SharedDataUtil;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.vertx.core.http.HttpServerOptions;
+
+public class RestVerticle extends AbstractRestVerticle {
+
+  public RestVerticle() {
+    super(Constants.TEST_PACKAGE_NAME, new HttpServerOptions().setPort(8080));
+  }
+
+  @Override
+  protected ClassInjector getInjector() {
+    return SharedDataUtil.getInstance(this.vertx.getDelegate(), GuiceInjector.class);
+  }
+
+  @Override
+  protected JsonProvider getJsonProvider() {
+    return new JacksonProvider(new ObjectMapper().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES));
+  }
+}

--- a/src/test/resources/config/swagger/swagger-info.json
+++ b/src/test/resources/config/swagger/swagger-info.json
@@ -1,0 +1,10 @@
+{
+  "prettyPrint": true,
+  "openAPI": {
+    "info": {
+      "version": "1.0",
+      "title": "test-apis-collection",
+      "description": "apis of test-application"
+    }
+  }
+}

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,19 @@
+<configuration scan="true" scanPeriod="1 seconds">
+    <property scope="context" name="HOSTNAME" value="${HOSTNAME}"/>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>
+                %date %highlight(%+5level) %-26thread %X{dd.trace_id:-0} %X{dd.span_id:-0} %logger{36} [%file:%line] %green(%msg) %n
+            </pattern>
+        </encoder>
+    </appender>
+
+    <logger name="com.dream11" level="trace"/>
+    <logger name="io.netty" level="info"/>
+
+    <root level="info">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+</configuration>


### PR DESCRIPTION
## **User description**
### Summary

SUMMARY_GOES_HERE

### Full changelog

* [Implement ...]
* [Add related tests]
* ...

### Issues resolved

Fix #XXX


___

## **CodeAnt-AI Description**
- Introduced a comprehensive REST API framework built on Vert.x and JAX-RS, including an abstract verticle for HTTP server management, custom dependency injection, and provider registration.
- Added custom annotations for timeout and type validation error handling, and implemented filters for logging, request/response processing, and per-request timeouts.
- Developed a robust error handling system with structured exceptions, error enums, and exception mappers for validation and web errors.
- Provided utilities for annotation-based class discovery, error conversion, and object serialization.
- Implemented parameter converters for numeric types with annotation-driven validation.
- Added extensive test infrastructure: integration tests for API validation, error handling, and backpressure; DTOs and routes for validation and timeout scenarios; dependency injection setup; and utility tests.
- Included configuration files for Swagger API documentation and Logback test logging.

This PR establishes a modular, extensible REST API foundation with strong validation, error handling, and test coverage. It enables rapid development of robust, well-documented REST services with custom error responses and observability.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><details><summary>24 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>AbstractRestVerticle.java</strong><dd><code>Add abstract REST Verticle with HTTP server and provider management</code></dd></summary>
<hr>

src/main/java/com/dream11/rest/AbstractRestVerticle.java
<li>Introduced an abstract Vert.x verticle for REST APIs with backpressure <br>support.<br> <li> Handles HTTP server lifecycle, JAX-RS route and provider registration, <br>and custom provider injection.<br> <li> Integrates filters, exception mappers, and JSON providers.<br> <li> Provides extensibility for dependency injection and JSON <br>serialization.<br>


</details>


  </td>
  <td><a href="https://github.com/akshaypatidar1999/vertx-rest/pull/1/files#diff-b948c0c552f6a6933af7ae4b4f38f6969611681c4d8a4bb1390f0adae4db6c81">+154/-0</a>&nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>ClassInjector.java</strong><dd><code>Introduce ClassInjector interface for dependency injection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dream11/rest/ClassInjector.java
<li>Added an interface for dependency injection to provide instances of <br>classes.<br>


</details>


  </td>
  <td><a href="https://github.com/akshaypatidar1999/vertx-rest/pull/1/files#diff-b18389d0365ac738a93253db4755060bd4b8f24f0b77a4972b0d3f533e0c5549">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>Timeout.java</strong><dd><code>Add Timeout annotation for resource-level timeouts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dream11/rest/annotation/Timeout.java
<li>Added a custom annotation to specify timeout and HTTP status code for <br>JAX-RS resources.<br>


</details>


  </td>
  <td><a href="https://github.com/akshaypatidar1999/vertx-rest/pull/1/files#diff-8e726d60ff13120368922d9cee183fc1746cd7972e9f43d7a224b8d8f529997c">+19/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>TypeValidationError.java</strong><dd><code>Add TypeValidationError annotation for parameter validation</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dream11/rest/annotation/TypeValidationError.java
<li>Introduced annotation for custom error code/message on type validation <br>errors.<br>


</details>


  </td>
  <td><a href="https://github.com/akshaypatidar1999/vertx-rest/pull/1/files#diff-7f5c91cd0b913abd013401026b8b66710fb1e5d844bdfb8cc4c5cc058ffb93d5">+19/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>BaseParamConverter.java</strong><dd><code>Add base parameter converter with annotation-driven error handling</code></dd></summary>
<hr>

src/main/java/com/dream11/rest/converter/BaseParamConverter.java
<li>Added a base class for parameter converters supporting custom error <br>handling via annotations.<br>


</details>


  </td>
  <td><a href="https://github.com/akshaypatidar1999/vertx-rest/pull/1/files#diff-a429d26bc71efedbaef0fe95f8a4241679538dfef3ce41ea56ea4556e6d91f11">+40/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>DoubleParamConverter.java</strong><dd><code>Add DoubleParamConverter with error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dream11/rest/converter/DoubleParamConverter.java
<li>Added a parameter converter for Double with validation error support.<br>


</details>


  </td>
  <td><a href="https://github.com/akshaypatidar1999/vertx-rest/pull/1/files#diff-a7379091d1ea8af2e34748b5f939dc96befcadbf41a8abca4ae0155c6fbb2554">+21/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>FloatParamConverter.java</strong><dd><code>Add FloatParamConverter with error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dream11/rest/converter/FloatParamConverter.java
<li>Added a parameter converter for Float with validation error support.<br>


</details>


  </td>
  <td><a href="https://github.com/akshaypatidar1999/vertx-rest/pull/1/files#diff-d0cf49335724d8a3c5eaafee7f49f2bfedbc0bb5c8dc5963587e2eb7bddafbab">+21/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>IntegerParamConverter.java</strong><dd><code>Add IntegerParamConverter with error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dream11/rest/converter/IntegerParamConverter.java
<li>Added a parameter converter for Integer with validation error support.<br> <br>


</details>


  </td>
  <td><a href="https://github.com/akshaypatidar1999/vertx-rest/pull/1/files#diff-54b4c5424ca8531aeff7ff785d6c62e0546c97ae16a2d26030418450ac76e452">+21/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>LongParamConverter.java</strong><dd><code>Add LongParamConverter with error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dream11/rest/converter/LongParamConverter.java
<li>Added a parameter converter for Long with validation error support.<br>


</details>


  </td>
  <td><a href="https://github.com/akshaypatidar1999/vertx-rest/pull/1/files#diff-6802b9927ebcccc1dfda17838c72ce4b1c7d42db5fcb468319b58cb6a026c4dc">+22/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>RestError.java</strong><dd><code>Add RestError interface for error abstraction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dream11/rest/exception/RestError.java
<li>Defined an interface for REST error codes, messages, and status codes.<br> <br>


</details>


  </td>
  <td><a href="https://github.com/akshaypatidar1999/vertx-rest/pull/1/files#diff-c059cdb610ecffd34f127f662a58c928ef4c82f9b5b50699d183e92f60109511">+11/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>RestException.java</strong><dd><code>Add RestException class for structured REST errors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dream11/rest/exception/RestException.java
<li>Implemented a custom exception for REST errors with JSON <br>serialization.<br> <li> Supports construction from error enums and causes.<br>


</details>


  </td>
  <td><a href="https://github.com/akshaypatidar1999/vertx-rest/pull/1/files#diff-d4669e71ce4c0e25ce741a5d9f619741c1d0b01040697f150e0f5842cd52f3ee">+48/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>RestErrorEnum.java</strong><dd><code>Add RestErrorEnum for standard error codes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dream11/rest/exception/impl/RestErrorEnum.java
- Added an enum for standard REST error codes and messages.



</details>


  </td>
  <td><a href="https://github.com/akshaypatidar1999/vertx-rest/pull/1/files#diff-ba9842503bbc94e05e0db4385154bf178f8c4fc148d3e3d6fcfea0772321c89b">+18/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>GenericExceptionMapper.java</strong><dd><code>Add GenericExceptionMapper for uncaught exceptions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dream11/rest/exception/mapper/GenericExceptionMapper.java
<li>Added a JAX-RS exception mapper for generic Throwable, converting to <br>RestException.<br>


</details>


  </td>
  <td><a href="https://github.com/akshaypatidar1999/vertx-rest/pull/1/files#diff-1185272ccaf673eede96e4d7273476cb409ca6079b6e3822b15eaff737f6542c">+19/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>ValidationExceptionMapper.java</strong><dd><code>Add ValidationExceptionMapper for validation errors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dream11/rest/exception/mapper/ValidationExceptionMapper.java
<li>Added a JAX-RS exception mapper for validation exceptions, returning <br>structured error responses.<br>


</details>


  </td>
  <td><a href="https://github.com/akshaypatidar1999/vertx-rest/pull/1/files#diff-a66cab3bbcc57b786fba8f8cd37968356d88bfb40e7d6c329bf6ec4e8a3d563e">+19/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>WebApplicationExceptionMapper.java</strong><dd><code>Add WebApplicationExceptionMapper for web errors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dream11/rest/exception/mapper/WebApplicationExceptionMapper.java
<li>Added a JAX-RS exception mapper for WebApplicationException, wrapping <br>in RestException.<br>


</details>


  </td>
  <td><a href="https://github.com/akshaypatidar1999/vertx-rest/pull/1/files#diff-1a6bdff369b4460511afdae72b3d58b4859b0b4b1b43218f2952e3b2d9f0a671">+21/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>LoggerFilter.java</strong><dd><code>Add LoggerFilter for detailed request/response logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dream11/rest/filter/LoggerFilter.java
<li>Implemented a request/response logging filter with timing and <br>body/header logging.<br>


</details>


  </td>
  <td><a href="https://github.com/akshaypatidar1999/vertx-rest/pull/1/files#diff-f33d024a5ddb6f434883db45cf1e3b4cd918efe726ef750461e269feab7b34fc">+53/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>RequestResponseFilter.java</strong><dd><code>Add RequestResponseFilter base class for filters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dream11/rest/filter/RequestResponseFilter.java
<li>Added an abstract base filter for request/response processing and <br>entity serialization.<br>


</details>


  </td>
  <td><a href="https://github.com/akshaypatidar1999/vertx-rest/pull/1/files#diff-cd8cfdbcab1f30c6df3ece49b2b6d3dae46bbb51e8ecb90a812c60dd4930b82e">+19/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>TimeoutFilter.java</strong><dd><code>Add TimeoutFilter for per-request timeout enforcement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dream11/rest/filter/TimeoutFilter.java
<li>Implemented a filter to enforce request timeouts using Vert.x timers <br>and custom error responses.<br>


</details>


  </td>
  <td><a href="https://github.com/akshaypatidar1999/vertx-rest/pull/1/files#diff-12cc18a865a0efe16ddf31af2e1a9b27b33654a306447bc305c7a3ffa4f20454">+73/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>JsonProvider.java</strong><dd><code>Add JsonProvider interface for JSON serialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dream11/rest/provider/JsonProvider.java
- Added a marker interface for JSON providers.



</details>


  </td>
  <td><a href="https://github.com/akshaypatidar1999/vertx-rest/pull/1/files#diff-4e8867c82e51cb3f16a847fd2ba5cfff6f1d3446e068840806f7bf34bb4d50c2">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>ParamConverterProvider.java</strong><dd><code>Add ParamConverterProvider for numeric type conversion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dream11/rest/provider/ParamConverterProvider.java
<li>Implemented a JAX-RS ParamConverterProvider for numeric types with <br>validation support.<br>


</details>


  </td>
  <td><a href="https://github.com/akshaypatidar1999/vertx-rest/pull/1/files#diff-aa03cf4d3ada611d5ccad8b371cec443f8a200075f7acf09e6587cf1a8632b33">+27/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>JacksonProvider.java</strong><dd><code>Add JacksonProvider for JSON with validation error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dream11/rest/provider/impl/JacksonProvider.java
<li>Implemented a Jackson-based JSON provider with support for <br>TypeValidationError annotation.<br> <li> Handles JSON mapping exceptions and returns structured errors.<br>


</details>


  </td>
  <td><a href="https://github.com/akshaypatidar1999/vertx-rest/pull/1/files#diff-7f0dd5f6f8a89ca818c864be968dfa44d4bf14ccbce63667bcf9d09b22257c8e">+54/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>AnnotationUtil.java</strong><dd><code>Add AnnotationUtil for annotation-based class discovery</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dream11/rest/util/AnnotationUtil.java
<li>Added a utility class to find classes with a specific annotation using <br>Reflections.<br>


</details>


  </td>
  <td><a href="https://github.com/akshaypatidar1999/vertx-rest/pull/1/files#diff-ecab586eab0b6d1b4d5b7d9ebcac1395042f48ed32afbdaf884acdaf0362dce0">+15/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>ExceptionUtil.java</strong><dd><code>Add ExceptionUtil for error conversion and formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dream11/rest/util/ExceptionUtil.java
<li>Added utility methods for parsing and constructing RestExceptions from <br>generic throwables or error enums.<br>


</details>


  </td>
  <td><a href="https://github.com/akshaypatidar1999/vertx-rest/pull/1/files#diff-b1fac1c3e93c9ce552291b4b508276c34a6ab910c961387cbe36e28f39b965c8">+20/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>RestUtil.java</strong><dd><code>Add RestUtil for object-to-string serialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dream11/rest/util/RestUtil.java
<li>Added utility for serializing objects to JSON strings using Jackson or <br>Vert.x types.<br>


</details>


  </td>
  <td><a href="https://github.com/akshaypatidar1999/vertx-rest/pull/1/files#diff-ee5a444beb5c91433f79a9d2d4725ffa367554cc82f52ff2684d1989bde751af">+25/-0</a>&nbsp; &nbsp; </td>
</tr>
</table></details></td></tr><tr><td><strong>Configuration changes
</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>package-info.java</strong><dd><code>Add package-info for Vert.x codegen module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dream11/rest/package-info.java
- Added package-level annotation for Vert.x code generation.



</details>


  </td>
  <td><a href="https://github.com/akshaypatidar1999/vertx-rest/pull/1/files#diff-896ef988a15695af1d8e09b677974ad487699ce20e8879786c8c4e659163a55c">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></details></td></tr><tr><td><strong>Tests
</strong></td><td><details><summary>16 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>Constants.java</strong><dd><code>Add Constants class for test configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/test/java/com/dream11/rest/Constants.java
<li>Added constants for test package, route paths, and application port.<br>


</details>


  </td>
  <td><a href="https://github.com/akshaypatidar1999/vertx-rest/pull/1/files#diff-c11876b1850de626327761a05f0d70c82c92e9e5d2d7a92457d0a691fcc2dd0d">+12/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>RestApiIT.java</strong><dd><code>Add integration tests for REST API validation and error handling</code></dd></summary>
<hr>

src/test/java/com/dream11/rest/RestApiIT.java
<li>Added integration tests for REST API covering validation, timeouts, <br>error handling, and backpressure.<br> <li> Tests various request/response scenarios and error codes.<br>


</details>


  </td>
  <td><a href="https://github.com/akshaypatidar1999/vertx-rest/pull/1/files#diff-5377137b4fc199031233c6ec3b51d0a7f53c97ccf3018224b0d11386b6d378ed">+173/-0</a>&nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>Setup.java</strong><dd><code>Add Setup extension for test environment initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/test/java/com/dream11/rest/Setup.java
<li>Added JUnit extension for setting up Vert.x, dependency injection, and <br>deploying test verticle.<br>


</details>


  </td>
  <td><a href="https://github.com/akshaypatidar1999/vertx-rest/pull/1/files#diff-73486e99a2f1eab16040592b0957a9110ddc8a90890cfb2716119b6855f1bcf5">+38/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>ValidationTestReqDTO.java</strong><dd><code>Add ValidationTestReqDTO for request body validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/test/java/com/dream11/rest/dto/ValidationTestReqDTO.java
<li>Added DTO for validation tests with NotNull and TypeValidationError <br>annotations.<br>


</details>


  </td>
  <td><a href="https://github.com/akshaypatidar1999/vertx-rest/pull/1/files#diff-b8b8d9a6baa4b2fe0495eb1a5bcb73099b57985997d43bde0970b3c51ef568bf">+14/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>RestAppError.java</strong><dd><code>Add RestAppError enum for test error codes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/test/java/com/dream11/rest/exception/RestAppError.java
<li>Added a test enum implementing RestError for custom error scenarios.<br>


</details>


  </td>
  <td><a href="https://github.com/akshaypatidar1999/vertx-rest/pull/1/files#diff-54d40f94915233e3f1cb529eeb05c213471ed7319276792d181e0ea833a6abc7">+16/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>RestExceptionTest.java</strong><dd><code>Add unit tests for RestException class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/test/java/com/dream11/rest/exception/RestExceptionTest.java
- Added unit tests for RestException construction and behavior.



</details>


  </td>
  <td><a href="https://github.com/akshaypatidar1999/vertx-rest/pull/1/files#diff-991fce04b45c3020a3b9faa3264a586ae3cc547ce2585e8ee38c84ac4faf15d6">+29/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>GuiceInjector.java</strong><dd><code>Add GuiceInjector for test dependency injection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/test/java/com/dream11/rest/injector/GuiceInjector.java
<li>Implemented a Guice-based ClassInjector for dependency injection in <br>tests.<br>


</details>


  </td>
  <td><a href="https://github.com/akshaypatidar1999/vertx-rest/pull/1/files#diff-ace582be09a67ce7a962237615147c5ba224a8f16092297fd0291200fde25528">+16/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>TimeoutRoute.java</strong><dd><code>Add TimeoutRoute for timeout annotation testing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/test/java/com/dream11/rest/route/TimeoutRoute.java
<li>Added test route with Timeout annotation for timeout behavior testing.<br> <br>


</details>


  </td>
  <td><a href="https://github.com/akshaypatidar1999/vertx-rest/pull/1/files#diff-9d05e4a9d638b94e666094534cb99cb305551e74d835c43d3c1f549dd4cfb5df">+46/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>ValidationCheckRoute.java</strong><dd><code>Add ValidationCheckRoute for parameter and body validation tests</code></dd></summary>
<hr>

src/test/java/com/dream11/rest/route/ValidationCheckRoute.java
<li>Added test route for validation checks on headers, path, query, and <br>body parameters.<br>


</details>


  </td>
  <td><a href="https://github.com/akshaypatidar1999/vertx-rest/pull/1/files#diff-33b09e06002aa008b355ed3cd0887fdf01286600eb8c07d09457bfad6b531569">+55/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>AnnotationUtilTest.java</strong><dd><code>Add unit test for AnnotationUtil class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/test/java/com/dream11/rest/util/AnnotationUtilTest.java
<li>Added unit test for AnnotationUtil to verify annotation-based class <br>discovery.<br>


</details>


  </td>
  <td><a href="https://github.com/akshaypatidar1999/vertx-rest/pull/1/files#diff-4fe968d02cdc8e738805203ed7f2feb13fadba7fffeaebe74519e3990307420d">+27/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>ExceptionUtilTest.java</strong><dd><code>Add unit tests for ExceptionUtil class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/test/java/com/dream11/rest/util/ExceptionUtilTest.java
<li>Added unit tests for ExceptionUtil covering throwable parsing and <br>error formatting.<br>


</details>


  </td>
  <td><a href="https://github.com/akshaypatidar1999/vertx-rest/pull/1/files#diff-c5d53c1a5a184ec1b1a7fb955380509196c0a8924afc4657e2cf6fcb5edcb139">+56/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>RestUtilTest.java</strong><dd><code>Add unit tests for RestUtil serialization utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/test/java/com/dream11/rest/util/RestUtilTest.java
<li>Added unit tests for RestUtil object-to-string serialization logic.<br>


</details>


  </td>
  <td><a href="https://github.com/akshaypatidar1999/vertx-rest/pull/1/files#diff-0ff507e031ddd66762096f08f05f0efba3d0ce2435e5fc3044e5c42168cc3330">+52/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>SharedDataUtil.java</strong><dd><code>Add SharedDataUtil for singleton management in tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/test/java/com/dream11/rest/util/SharedDataUtil.java
- Added utility for managing singleton/shared data in Vert.x tests.



</details>


  </td>
  <td><a href="https://github.com/akshaypatidar1999/vertx-rest/pull/1/files#diff-b1cf2aefda50f190a7d7d58a30b40981e2ac2ca2f808d66440026087a42e2550">+56/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>RestVerticle.java</strong><dd><code>Add RestVerticle for test deployment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/test/java/com/dream11/rest/verticle/RestVerticle.java
<li>Added a concrete test verticle extending AbstractRestVerticle for <br>integration testing.<br>


</details>


  </td>
  <td><a href="https://github.com/akshaypatidar1999/vertx-rest/pull/1/files#diff-23fc76ebcf0754765ea96cb6f3b68aede222bfe3b111cf8cd059d5ad7d0ee504">+30/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>swagger-info.json</strong><dd><code>Add Swagger info JSON for test API documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/test/resources/config/swagger/swagger-info.json
- Added Swagger configuration for test APIs.



</details>


  </td>
  <td><a href="https://github.com/akshaypatidar1999/vertx-rest/pull/1/files#diff-9a87860ccbede98902888a95031c85b2d29ff0fc0ed424c06061c7f00ba895b8">+10/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>logback-test.xml</strong><dd><code>Add Logback configuration for test logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/test/resources/logback-test.xml
- Added Logback configuration for test logging.



</details>


  </td>
  <td><a href="https://github.com/akshaypatidar1999/vertx-rest/pull/1/files#diff-4ca184e5d3f39db0cbc21d76d438877f2f39251d0768e4e9f42728c610fc408e">+19/-0</a>&nbsp; &nbsp; </td>
</tr>
</table></details></td></tr></tr></tbody></table><details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request establishes a comprehensive REST API framework with core components including an abstract verticle, dependency injection, custom annotations, parameter converters, and structured exception handling. It enhances the framework with robust testing infrastructure, including integration and unit tests, to ensure validation, timeout handling, and proper error responses.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 5
</div>